### PR TITLE
Hot fix to upload the model.pth from Google Cloud Storage

### DIFF
--- a/cloudbuild_api.yaml
+++ b/cloudbuild_api.yaml
@@ -1,4 +1,9 @@
 steps:
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'Download Model'
+  args: ['storage', 'cp', 'gs://kadis-bucket/models/best_model.pt', 'models/model.pth']
+
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build container image'
   args: [


### PR DESCRIPTION
Add a step to download the model from Google Cloud Storage
It is necessary to fix the error that occurs when Google Cloud Build automatically tries to build the container.
Error snippet:
<html><body>
<!--StartFragment-->
Step 13/19 : COPY models/model.pth ./models/model.pth
--
<span _ngcontent-pantheon-host-app-id__pantheon-host-binary-id-c1258107855=""><span _ngcontent-pantheon-host-app-id__pantheon-host-binary-id-c1258107855="" class="gcb-log-white-space-pre ng-star-inserted">COPY failed: file not found in build context or excluded by .dockerignore: stat models/model.pth: file does not exist</span></span><!--EndFragment-->
</body>
</html>