### PR TITLE
Hotfix for downloading processed artefacts while cloud build

### DIFF
--- a/cloudbuild_api.yaml
+++ b/cloudbuild_api.yaml
@@ -4,6 +4,15 @@ steps:
   id: 'Download Model'
   args: ['storage', 'cp', 'gs://kadis-bucket/models/best_model.pt', 'models/model.pth']
 
+- name: gcr.io/cloud-builders/gsutil
+  id: 'Download Preprocessing Artifacts'
+  args:
+    - cp
+    - gs://kadis-bucket/data/processed/scaler.joblib
+    - gs://kadis-bucket/data/processed/feature_columns.json
+    - gs://kadis-bucket/data/processed/label_encoder.joblib
+    - data/processed/
+
 - name: 'gcr.io/cloud-builders/docker'
   id: 'Build container image'
   args: [

--- a/dockerfiles/api.dockerfile
+++ b/dockerfiles/api.dockerfile
@@ -26,7 +26,7 @@ RUN uv pip install --system --no-cache \
 
 # Copy metadata first (helps with caching)
 COPY pyproject.toml README.md* ./
-# Copy source source files
+# Copy source files
 COPY src/${PROJECT_NAME}/__init__.py ./src/${PROJECT_NAME}/__init__.py
 COPY src/${PROJECT_NAME}/api.py ./src/${PROJECT_NAME}/api.py
 COPY src/${PROJECT_NAME}/model.py ./src/${PROJECT_NAME}/model.py

--- a/dockerfiles/api.dockerfile
+++ b/dockerfiles/api.dockerfile
@@ -26,11 +26,13 @@ RUN uv pip install --system --no-cache \
 
 # Copy metadata first (helps with caching)
 COPY pyproject.toml README.md* ./
-# Copy source files
+# Copy source source files
 COPY src/${PROJECT_NAME}/__init__.py ./src/${PROJECT_NAME}/__init__.py
 COPY src/${PROJECT_NAME}/api.py ./src/${PROJECT_NAME}/api.py
 COPY src/${PROJECT_NAME}/model.py ./src/${PROJECT_NAME}/model.py
+# Copy model
 COPY models/model.pth ./models/model.pth
+# Copy processed data files
 COPY data/processed/scaler.joblib ./data/processed/scaler.joblib
 COPY data/processed/feature_columns.json ./data/processed/feature_columns.json
 COPY data/processed/label_encoder.joblib ./data/processed/label_encoder.joblib


### PR DESCRIPTION
Add steps to download preprocessing artifacts and update the Dockerfile to include them.
The Docker missed the processed data (three files) from the bucket.

Error:
<html><body>
<!--StartFragment-->
Step 14/19 : COPY data/processed/scaler.joblib ./data/processed/scaler.joblib
--


<span _ngcontent-pantheon-host-app-id__pantheon-host-binary-id-c1258107855=""><span _ngcontent-pantheon-host-app-id__pantheon-host-binary-id-c1258107855="" class="gcb-log-white-space-pre ng-star-inserted">COPY failed: file not found in build context or excluded by .dockerignore: stat data/processed/scaler.joblib: file does not exist</span></span><!--EndFragment-->
</body>
</html>