### PR TITLE
Update docker-compose.yml for improved reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,21 +11,21 @@ services:
       - IS_DOCKER=1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 15s   # Wait 15s between checks
+      interval: 30s   # Wait 30s between checks
       timeout: 10s   # Give the curl command 10s to respond
-      retries: 10    # Try 10 times before giving up
-      start_period: 30s # DON'T check at all for the first 30s (Model loading time)
+      retries: 20    # Try 20 times before giving up
+      start_period: 300s # DON'T check at all for the first 300s (Model loading time)
 
   # The Frontend UI (Streamlit)
   app:
     build:
       context: .
-      dockerfile: dockerfiles/streamlit_app.dockerfile # This is the Dockerfile you shared earlier
+      dockerfile: dockerfiles/streamlit_app.dockerfile
     ports:
       - "8501:8501"
     environment:
       - PORT=8501
-      - API_URL=http://api:8000  # <--- CRITICAL: Uses the service name 'api'
+      - API_URL=http://api:8000 # Point to the API service
       - IS_DOCKER=1
     depends_on:
       api:


### PR DESCRIPTION
Noticed that the running `docker-compose.yml` sometimes fails due to an unsuccessful health check.
Update healthcheck parameters for improved reliability.
Test:
```
docker compose up --build
```